### PR TITLE
Allow anonymous authentication

### DIFF
--- a/src/Silex/Component/Security/Http/Firewall/JWTListener.php
+++ b/src/Silex/Component/Security/Http/Firewall/JWTListener.php
@@ -42,18 +42,11 @@ class JWTListener implements ListenerInterface {
 
                 $authToken = $this->authenticationManager->authenticate($token);
                 $this->securityContext->setToken($authToken);
-
-                return;
-
             } catch (\UnexpectedValueException $e) {
 
             } catch (AuthenticationException $e) {
 
             }
         }
-
-        $response = new Response();
-        $response->setStatusCode(Response::HTTP_FORBIDDEN);
-        $event->setResponse($response);
     }
 }


### PR DESCRIPTION
Убрал принудительный присвоение response. В этом случае если указать 'anonymous' => true в конфигурации firewall'a, то при обращении к ресурсам для которых разрешен анонимный доступ не будет выкинута ошибка авторизации и вызов $app['security']->getToken() вернет экземпляр объекта AnonymousToken.
