### PR TITLE
Fixed hardcoded value for "users" option in security.firewall

### DIFF
--- a/src/Silex/Provider/SecurityJWTServiceProvider.php
+++ b/src/Silex/Provider/SecurityJWTServiceProvider.php
@@ -57,7 +57,19 @@ class SecurityJWTServiceProvider implements ServiceProviderInterface
          * Class for usage custom user provider
          */
         $app['security.jwt.authentication_provider'] = function() use ($app) {
-            return new JWTProvider($app['users']);
+            foreach ($app['security.firewalls'] as $name => $firewall) {
+                if (isset($firewall['users'])){
+                    $users = $firewall['users'];
+                    break;
+                }
+                continue;
+            }
+
+            if (! isset($users)){
+                throw new \LogicException('Invalid or missing security.firewalls configuration for "users"');
+            }
+
+            return new JWTProvider($users);
         };
 
         $app['security.entry_point.jwt'] = function() use ($app) {


### PR DESCRIPTION
Hi Anton,

I wanted to have different name than "users" in my app configuration and I couldn't do it because it's hardcoded. I have no much experience in Silex but I hope so that this is acceptable solution for this problem :-)

Thanks
Milan
