### PR TITLE
Allow configurable username claim

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,8 +39,8 @@ $app['security.jwt'] = [
     'secret_key' => 'Very_secret_key',
     'life_time'  => 86400,
     'options'    => [
-        'header_name' => 'X-Access-Token',
-        // default null, option for usage normal oauth2 header
+        'username_claim' => 'sub', // default name, option specifying claim containing username
+        'header_name' => 'X-Access-Token', // default null, option for usage normal oauth2 header
         'token_prefix' => 'Bearer',
     ]
 ];

--- a/src/Silex/Component/Security/Http/Authentication/Provider/JWTProvider.php
+++ b/src/Silex/Component/Security/Http/Authentication/Provider/JWTProvider.php
@@ -33,12 +33,7 @@ class JWTProvider implements AuthenticationProviderInterface
      */
     public function authenticate(TokenInterface $token)
     {
-
-        if ($token instanceof JWTToken) {
-            $userName = $token->getTokenContext()->name;
-        } else {
-            $userName = $token->getUsername();
-        }
+        $userName = $token->getUsername();
 
         $user = $this->userProvider->loadUserByUsername($userName);
 

--- a/src/Silex/Component/Security/Http/Authentication/Provider/JWTProvider.php
+++ b/src/Silex/Component/Security/Http/Authentication/Provider/JWTProvider.php
@@ -9,7 +9,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
-class JWTProvider implements AuthenticationProviderInterface {
+class JWTProvider implements AuthenticationProviderInterface
+{
 
     /**
      * @var UserProviderInterface
@@ -43,7 +44,7 @@ class JWTProvider implements AuthenticationProviderInterface {
 
         if (null != $user) {
             $lastContext = $token->getTokenContext();
-            
+
             $token = new JWTToken($user->getRoles());
             $token->setTokenContext($lastContext);
             $token->setUser($user);

--- a/src/Silex/Component/Security/Http/Firewall/JWTListener.php
+++ b/src/Silex/Component/Security/Http/Firewall/JWTListener.php
@@ -61,6 +61,7 @@ class JWTListener implements ListenerInterface {
 
                 $token = new JWTToken();
                 $token->setTokenContext($decoded);
+                $token->setUsernameClaim($this->options['username_claim']);
 
                 $authToken = $this->authenticationManager->authenticate($token);
                 $this->securityContext->setToken($authToken);

--- a/src/Silex/Component/Security/Http/Token/JWTToken.php
+++ b/src/Silex/Component/Security/Http/Token/JWTToken.php
@@ -11,6 +11,16 @@ class JWTToken extends AbstractToken implements TokenInterface
     protected $tokenContext;
 
     /**
+     * Set username claim for JWT token
+     *
+     * @param $usernameClaim
+     */
+    public function setUsernameClaim($usernameClaim)
+    {
+        $this->usernameClaim = $usernameClaim;
+    }
+
+    /**
      * Set token context from JWT tokens
      *
      * @param $tokenContext
@@ -38,5 +48,16 @@ class JWTToken extends AbstractToken implements TokenInterface
     public function getCredentials()
     {
         return '';
+    }
+
+    /**
+     * Returns the user username.
+     *
+     * @return mixed The user username
+     */
+    public function getUsername()
+    {
+        return (isset($this->tokenContext->{$this->usernameClaim})) ?
+            $this->tokenContext->{$this->usernameClaim} : null;
     }
 }

--- a/src/Silex/Provider/SecurityJWTServiceProvider.php
+++ b/src/Silex/Provider/SecurityJWTServiceProvider.php
@@ -16,11 +16,12 @@ class SecurityJWTServiceProvider implements ServiceProviderInterface
 
     public function register(Container $app)
     {
-        $app['security.jwt'] = array_merge([
+        $app['security.jwt'] = array_replace_recursive([
             'secret_key' => 'default_secret_key',
             'life_time' => 86400,
             'algorithm'  => ['HS256'],
             'options' => [
+                'username_claim' => 'name',
                 'header_name' => 'SECURITY_TOKEN_HEADER',
                 'token_prefix' => null,
             ]


### PR DESCRIPTION
This PR allows the property used from the token to identify the user to be configured.

The [JWT spec](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#rfc.section.4.1.2) states:-

```
4.1.2. "sub" (Subject) Claim

The sub (subject) claim identifies the principal that is the subject of the
JWT. The claims in a JWT are normally statements about the subject. The subject
value MUST either be scoped to be locally unique in the context of the issuer
or be globally unique. The processing of this claim is generally application
specific. The sub value is a case-sensitive string containing a StringOrURI
value. Use of this claim is OPTIONAL.
```

And from [JsonWebTokens in Auth0](https://auth0.com/docs/jwt):-

```
sub the subject, is a string formed by the connection used to authenticate the
user (e.g. google-oauth2, linkedin, etc). and the unique id of the logged in
user in that identity provider.
```

I figured it'd be useful to allow this to be configurable (as is currently hardcoded to `name`).

My JWT tokens come from a difference source and this allows me to specify the claim which contains the username to look up. Still defaults to `name` unless specified otherwise.

For example:-

``` php
$app['security.jwt'] = [
    'secret_key' => 'Very_secret_key',
    'life_time'  => 86400,
    'algorithm'  => ['HS256'],
    'options'    => [
        'username_claim' => 'sub',
        'header_name'  => 'X-Access-Token',
        'token_prefix' => 'Bearer',
    ]
];
```
