### PR TITLE
method supports is called automatically by symfony

### DIFF
--- a/src/Silex/Component/Security/Http/Authentication/Provider/JWTProvider.php
+++ b/src/Silex/Component/Security/Http/Authentication/Provider/JWTProvider.php
@@ -46,10 +46,6 @@ class JWTProvider implements AuthenticationProviderInterface
      */
     public function authenticate(TokenInterface $token)
     {
-        if (!$this->supports($token)) {
-            return;
-        }
-
         if (!$user = $token->getUser()) {
             throw new AuthenticationException('JWT auth failed');
         }


### PR DESCRIPTION
According to the documentation, supports is called by AuthenticationProviderManager automatically:
Each provider (since it implements AuthenticationProviderInterface) has a method supports() by which the AuthenticationProviderManager can determine if it supports the given token.

http://symfony.com/doc/current/components/security/authentication.html#authentication-providers